### PR TITLE
Replace jcenter by mavencentral

### DIFF
--- a/firebase-perf-rc-android-finish/build.gradle
+++ b/firebase-perf-rc-android-finish/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.2'
@@ -22,7 +22,7 @@ plugins {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         mavenLocal()
     }
 

--- a/firebase-perf-rc-android-finish/build.gradle
+++ b/firebase-perf-rc-android-finish/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.2'
-        classpath 'com.google.gms:google-services:4.3.5'
+        classpath 'com.google.gms:google-services:4.3.10'
 
         // Add the dependency for the Performance Monitoring plugin
         classpath 'com.google.firebase:perf-plugin:1.3.4'  // Performance Monitoring plugin

--- a/firebase-perf-rc-android-start/app/build.gradle
+++ b/firebase-perf-rc-android-start/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'com.google.gms.google-services'
 
 android {
     compileSdkVersion 30

--- a/firebase-perf-rc-android-start/build.gradle
+++ b/firebase-perf-rc-android-start/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.2'
@@ -19,7 +19,7 @@ plugins {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         mavenLocal()
     }
 

--- a/firebase-perf-rc-android-start/build.gradle
+++ b/firebase-perf-rc-android-start/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.2'
-        classpath 'com.google.gms:google-services:4.3.5'
+        classpath 'com.google.gms:google-services:4.3.10'
     }
 }
 


### PR DESCRIPTION
This Pull Request replaces all references of `jcenter()` by `mavenCentral()`, since `jcenter()` repo is now deprecated. Both `start` and `finish` folders have been tested on an emulator, but they were crashing right after the launch due to missing plugins and outdated libraries. These updates/fixes were made in a separate commit and now they're both running.